### PR TITLE
Harmonize projects

### DIFF
--- a/drf/notes/notes/settings.py
+++ b/drf/notes/notes/settings.py
@@ -56,7 +56,7 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "Notes API",
+    "TITLE": "Drf Notes Api",
     "DESCRIPTION": "Example notes application",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,

--- a/drf/scripts/run.sh
+++ b/drf/scripts/run.sh
@@ -2,4 +2,4 @@ project_path=$(dirname $0)/../notes
 
 pushd $project_path
 python -m manage migrate
-python -m manage runserver
+python -m manage runserver 8003

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -8,7 +8,7 @@ from app.database.session import get_session
 from app.service.model import Note, NoteInput
 from fastapi import Depends, FastAPI, Request, status
 
-app = FastAPI()
+app = FastAPI(title="FastApi Notes")
 
 
 @app.exception_handler(InvalidRequestError)

--- a/fastapi/scripts/run.sh
+++ b/fastapi/scripts/run.sh
@@ -1,3 +1,3 @@
 alembic upgrade head
-uvicorn app.main:app --reload
+UVICORN_PORT=8002 uvicorn app.main:app --reload
 

--- a/flask/app/templates/redoc.html
+++ b/flask/app/templates/redoc.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-    <title>Notes - ReDoc</title>
+    <title>Flask Notes Api - ReDoc</title>
     </head>
     <body>
     <redoc spec-url='/openapi.json'></redoc>

--- a/flask/app/views.py
+++ b/flask/app/views.py
@@ -12,7 +12,7 @@ from app.service.model import NoteSchema, note_schema, notes_schema
 from flask import Response, render_template, request
 
 spec = APISpec(
-    title="Notes",
+    title="Flask Notes",
     version="1.0.0",
     openapi_version="3.0.2",
     plugins=[FlaskPlugin(), MarshmallowPlugin()],

--- a/flask/scripts/run.sh
+++ b/flask/scripts/run.sh
@@ -1,3 +1,3 @@
 alembic upgrade head
-flask --app app.main --debug run --host 0.0.0.0 --port 8000
+flask --app app.main --debug run --host 0.0.0.0 --port 8001
 


### PR DESCRIPTION
* Run vanilla, flask, fastapi, and drf all on different ports. This way we can run them at the same time, to more easily compare them.
* Include the framework name in the title of the generated api doc.